### PR TITLE
Allow changing email address

### DIFF
--- a/dist/api/models/user.js
+++ b/dist/api/models/user.js
@@ -353,6 +353,27 @@ class UserAPI {
             throw new errors_1.ModelError(err);
         }
     }
+    async putEmail(sessionUser, username, { email, password }) {
+        const user = await this.getOne({ 'user.username': username }, true);
+        if (Number(sessionUser.id) !== Number(user.id))
+            throw new errors_1.ForbiddenError();
+        const isCorrectLogin = this.validatePassword(password, user.password, user.salt);
+        if (!isCorrectLogin)
+            throw new errors_1.UnauthorizedError('Incorrect password');
+        try {
+            const data = await (0, utils_1.executeQuery)(`
+        UPDATE user
+        SET
+          email = ?,
+          verified = ?
+        WHERE id = ?
+      `, [email, false, user.id]);
+            return data;
+        }
+        catch (err) {
+            throw new errors_1.ModelError(err);
+        }
+    }
     async putPassword(sessionUser, username, { oldPassword, newPassword }) {
         const user = await this.getOne({ 'user.username': username }, true);
         if (Number(sessionUser.id) !== Number(user.id))

--- a/dist/api/routes.js
+++ b/dist/api/routes.js
@@ -48,7 +48,13 @@ function default_1(app, upload) {
                             res.json(err.data);
                         }
                         else {
-                            res.end();
+                            try {
+                                res.json(err.message);
+                            }
+                            catch (err) {
+                                logger_1.default.error(err);
+                                res.end();
+                            }
                         }
                     }
                 }

--- a/dist/api/routes.js
+++ b/dist/api/routes.js
@@ -118,6 +118,7 @@ function default_1(app, upload) {
                     }),
                 ]),
                 new APIRoute('/username', { PUT: (req) => _1.default.user.putUsername(req.session.user, req.params.username, req.body.username) }),
+                new APIRoute('/email', { PUT: (req) => _1.default.user.putEmail(req.session.user, req.params.username, req.body) }),
                 new APIRoute('/password', { PUT: (req) => _1.default.user.putPassword(req.session.user, req.params.username, req.body) }),
                 new APIRoute('/notif-settings', { PUT: (req) => _1.default.notification.putSettings((req.session?.user?.username === req.params.username) ? req.session.user : null, req.body.username) }),
                 new APIRoute('/preferences', { PUT: (req) => _1.default.user.putPreferences(req.session.user, req.params.username, req.body) }),

--- a/dist/api/utils.js
+++ b/dist/api/utils.js
@@ -8,6 +8,7 @@ exports.executeQuery = executeQuery;
 exports.withTransaction = withTransaction;
 exports.getPfpUrl = getPfpUrl;
 exports.handleNotFoundAsNull = handleNotFoundAsNull;
+exports.handleErrorWithData = handleErrorWithData;
 const db_1 = __importDefault(require("../db"));
 const md5_1 = __importDefault(require("md5"));
 const logger_1 = __importDefault(require("../logger"));
@@ -256,6 +257,12 @@ function getPfpUrl(user) {
 function handleNotFoundAsNull(error) {
     if (error instanceof errors_1.NotFoundError) {
         return null;
+    }
+    throw error;
+}
+function handleErrorWithData(error) {
+    if (error.data) {
+        return error.data;
     }
     throw error;
 }

--- a/dist/middleware/auth.js
+++ b/dist/middleware/auth.js
@@ -74,8 +74,16 @@ const verifySessionOrRedirect = async (req, res, next) => {
         }
     }
 };
+const bypassEmailVerification = async (req, res, next) => {
+    const user = req.session.user;
+    if (user) {
+        user.verified = true;
+    }
+    next();
+};
 exports.default = {
     createSession,
     verifySession,
     verifySessionOrRedirect,
+    bypassEmailVerification,
 };

--- a/dist/views/index.js
+++ b/dist/views/index.js
@@ -113,7 +113,6 @@ function default_1(app) {
     };
     function use(method, path, site, middleware, handler) {
         app[method](`${config_1.ADDR_PREFIX}${path}`, ...middleware, async (req, res, next) => {
-            console.log(method, path);
             if (site(req) && !res.headersSent) {
                 try {
                     await handler(req, res);

--- a/dist/views/index.js
+++ b/dist/views/index.js
@@ -169,7 +169,7 @@ function default_1(app) {
     /* User Pages */
     get('/contacts', sites.ALL, [auth_1.default.verifySessionOrRedirect], pages_1.default.user.contactList);
     get('/users/:username', sites.ALL, [], pages_1.default.user.profilePage);
-    get('/settings', sites.ALL, [auth_1.default.verifySessionOrRedirect], pages_1.default.user.settings);
+    get('/settings', sites.ALL, [auth_1.default.bypassEmailVerification, auth_1.default.verifySessionOrRedirect], pages_1.default.user.settings);
     get('/verify', sites.ALL, [], pages_1.default.user.requestVerify);
     get('/verify/:key', sites.ALL, [], pages_1.default.user.verifyUser);
     get('/notifications', sites.ALL, [auth_1.default.verifySessionOrRedirect], pages_1.default.user.notifications);

--- a/dist/views/pages/user.js
+++ b/dist/views/pages/user.js
@@ -79,7 +79,7 @@ exports.default = {
             res.redirect(`${config_1.ADDR_PREFIX}/`);
             return;
         }
-        const data = await api_1.default.email.trySendVerifyLink(req.session.user, req.session.user.username);
+        const data = await api_1.default.email.trySendVerifyLink(req.session.user, req.session.user.username).catch(utils_1.handleErrorWithData);
         if (data && !(data instanceof Date) && data.alreadyVerified) {
             res.redirect(`${config_1.ADDR_PREFIX}${req.query.page || '/'}${req.query.search ? `?${req.query.search}` : ''}`);
             return;

--- a/src/api/models/user.ts
+++ b/src/api/models/user.ts
@@ -375,6 +375,25 @@ export class UserAPI {
     }
   }
 
+  async putEmail(sessionUser: User, username: string, { email, password }): Promise<ResultSetHeader> {
+    const user = await this.getOne({ 'user.username': username }, true);
+    if (Number(sessionUser.id) !== Number(user.id)) throw new ForbiddenError();
+    const isCorrectLogin = this.validatePassword(password, user.password, user.salt);
+    if (!isCorrectLogin) throw new UnauthorizedError('Incorrect password');
+    try {
+      const data = await executeQuery<ResultSetHeader>(`
+        UPDATE user
+        SET
+          email = ?,
+          verified = ?
+        WHERE id = ?
+      `, [email, false, user.id]);
+      return data;
+    } catch (err) {
+      throw new ModelError(err);
+    }
+  }
+
   async putPassword(sessionUser: User, username: string, { oldPassword, newPassword }): Promise<ResultSetHeader> {
     const user = await this.getOne({ 'user.username': username }, true);
     if (Number(sessionUser.id) !== Number(user.id)) throw new ForbiddenError();

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -119,6 +119,7 @@ export default function (app: Express, upload: Multer) {
           }),
         ]),
         new APIRoute('/username', { PUT: (req) => api.user.putUsername(req.session.user, req.params.username, req.body.username) }),
+        new APIRoute('/email', { PUT: (req) => api.user.putEmail(req.session.user, req.params.username, req.body) }),
         new APIRoute('/password', { PUT: (req) => api.user.putPassword(req.session.user, req.params.username, req.body) }),
         new APIRoute('/notif-settings', { PUT: (req) => api.notification.putSettings((req.session?.user?.username === req.params.username) ? req.session.user : null, req.body.username) }),
         new APIRoute('/preferences', { PUT: (req) => api.user.putPreferences(req.session.user, req.params.username, req.body) }),

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -52,7 +52,12 @@ export default function (app: Express, upload: Multer) {
             if (err.data) {
               res.json(err.data);
             } else {
-              res.end();
+              try {
+                res.json(err.message);
+              } catch (err) {
+                logger.error(err);
+                res.end();
+              }
             }
           }
         } else {

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -277,3 +277,10 @@ export function handleNotFoundAsNull(error: any): null {
   }
   throw error;
 }
+
+export function handleErrorWithData(error: any): null {
+  if (error.data) {
+    return error.data;
+  }
+  throw error;
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -76,8 +76,17 @@ const verifySessionOrRedirect = async (req: Request, res: Response, next: NextFu
   }
 }
 
+const bypassEmailVerification = async (req: Request, res: Response, next: NextFunction) => {
+  const user = req.session.user;
+  if (user) {
+    user.verified = true;
+  }
+  next();
+}
+
 export default {
   createSession,
   verifySession,
   verifySessionOrRedirect,
+  bypassEmailVerification,
 };

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -148,7 +148,7 @@ export default function(app: Express) {
   /* User Pages */
   get('/contacts', sites.ALL, [Auth.verifySessionOrRedirect], pages.user.contactList);
   get('/users/:username', sites.ALL, [], pages.user.profilePage);
-  get('/settings', sites.ALL, [Auth.verifySessionOrRedirect], pages.user.settings);
+  get('/settings', sites.ALL, [Auth.bypassEmailVerification, Auth.verifySessionOrRedirect], pages.user.settings);
   get('/verify', sites.ALL, [], pages.user.requestVerify);
   get('/verify/:key', sites.ALL, [], pages.user.verifyUser);
   get('/notifications', sites.ALL, [Auth.verifySessionOrRedirect], pages.user.notifications);

--- a/src/views/index.ts
+++ b/src/views/index.ts
@@ -85,7 +85,6 @@ export default function(app: Express) {
 
   function use(method: Method, path: string, site: SiteCheck, middleware: Handler[], handler: RouteHandler): void {
     app[method](`${ADDR_PREFIX}${path}`, ...middleware, async (req, res, next) => {
-      console.log(method, path)
       if (site(req) && !res.headersSent) {
         try {
           await handler(req, res);

--- a/src/views/pages/user.ts
+++ b/src/views/pages/user.ts
@@ -1,11 +1,7 @@
-import { ADDR_PREFIX, DEV_MODE } from '../../config';
-import Auth from '../../middleware/auth';
+import { ADDR_PREFIX } from '../../config';
 import api from '../../api';
 import md5 from 'md5';
-import { render } from '../../templates';
-import { perms, Cond, getPfpUrl, handleNotFoundAsNull } from '../../api/utils';
-import fs from 'fs/promises';
-import logger from '../../logger';
+import { perms, Cond, getPfpUrl, handleNotFoundAsNull, handleErrorWithData } from '../../api/utils';
 import { RouteHandler } from '..';
 import { NotFoundError } from '../../errors';
 
@@ -81,7 +77,7 @@ export default {
       res.redirect(`${ADDR_PREFIX}/`);
       return;
     }
-    const data = await api.email.trySendVerifyLink(req.session.user, req.session.user.username);
+    const data = await api.email.trySendVerifyLink(req.session.user, req.session.user.username).catch(handleErrorWithData);
     if (data && !(data instanceof Date) && data.alreadyVerified) {
       res.redirect(`${ADDR_PREFIX}${req.query.page || '/'}${req.query.search ? `?${req.query.search}` : ''}`);
       return;

--- a/templates/edit/settings.pug
+++ b/templates/edit/settings.pug
@@ -75,6 +75,44 @@ block content
 
       hr.mt-4
 
+      h3 #{T('Change Email')}
+      form#changeEmail
+        .inputGroup
+          label(for='emailChangePassword') #{T('Confirm password')}:
+          input(id='emailChangePassword' name='emailChangePassword' type='password')
+        .inputGroup
+          label(for='email') #{T('Email')}:
+          input(id='email' name='email' type='email' value=user.email)
+          small.row-2.col-2 #{T('If you change your email address, your account will have to be re-verified!')}
+          .d-flex
+            button(type='submit') #{T('Change Email')}
+
+        small.color-error.hidden#email-error
+
+        script.
+          (() => {
+            const form = document.forms.changeEmail;
+            const formError = document.querySelector('#email-error');
+            form.addEventListener('submit', async (e) => {
+              formError.classList.add('hidden');
+              e.preventDefault();
+
+              const value = form.email.value;
+              const password = form.emailChangePassword.value;
+              if (value === '#{user.email}') return;
+
+              const [response, data] = await putJSON(`/api/users/#{user.username}/email`, { email: value, password });
+              if (response.status === 200) {
+                window.location.reload();
+              } else {
+                formError.innerText = data;
+                formError.classList.remove('hidden');
+              }
+            });
+          })();
+
+      hr.mt-4
+
       if user.plan >= plans.BETA
         h3 #{T('Change Preferences')}
         form#changePreferences
@@ -152,6 +190,8 @@ block content
               }
             });
           })();
+
+      hr.mt-4
 
       h3 #{T('Request Account Deletion')}
       form#deleteAccount


### PR DESCRIPTION
closes #26, closes #198

Allow users to change their email address. The new email will have to be verified (even if the user has had that email in the past). To prevent getting locked out (in case a bad email is typed), also don't block the settings page behind the normal verification screen.