### PR TITLE
Add author filter for universe item page

### DIFF
--- a/dist/views/pages/universe.js
+++ b/dist/views/pages/universe.js
@@ -114,6 +114,7 @@ exports.default = {
             limit: req.getQueryParamAsNumber('limit'),
             type: req.getQueryParam('type'),
             tag: req.getQueryParam('tag'),
+            author: req.getQueryParam('author'),
             search,
         });
         res.prepareRender('universeItemList', {

--- a/src/views/pages/universe.ts
+++ b/src/views/pages/universe.ts
@@ -127,6 +127,7 @@ export default {
       limit: req.getQueryParamAsNumber('limit'),
       type: req.getQueryParam('type'),
       tag: req.getQueryParam('tag'),
+      author: req.getQueryParam('author'),
       search,
     });
     res.prepareRender('universeItemList', {


### PR DESCRIPTION
closes #169 

Adds the `author` filter to a universe's item list. This filter can currently only be set through the URL, fixing this should be part of #135.