### PR TITLE
Fix links not highlighting in editor

### DIFF
--- a/dist/lib/editor/index.js
+++ b/dist/lib/editor/index.js
@@ -60,7 +60,7 @@ const editorExtensions = (editMode, context) => ([
     Link_1.default.configure({
         enableClickSelection: editMode,
         openOnClick: !editMode,
-        ...(editMode ? {} : { shorthandResolver }),
+        shorthandResolver,
         context,
     }),
     ToC_1.default.configure({ context }),

--- a/src/lib/editor/index.ts
+++ b/src/lib/editor/index.ts
@@ -73,7 +73,7 @@ export const editorExtensions = (editMode: boolean, context?: TiptapContext) => 
   Link.configure({
     enableClickSelection: editMode,
     openOnClick: !editMode,
-    ...(editMode ? {} : { shorthandResolver }),
+    shorthandResolver,
     context,
   }),
   ToC.configure({ context }),


### PR DESCRIPTION
The `shorthandResolver` that highlights the links was, for some reason, disabled in the editor (could have been from an older design approach that I then scrapped).