### PR TITLE
Allow embedding video URLs

### DIFF
--- a/dist/lib/editor/extensions/IFrame.js
+++ b/dist/lib/editor/extensions/IFrame.js
@@ -1,0 +1,52 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const core_1 = require("@tiptap/core");
+exports.default = core_1.Node.create({
+    name: 'iframe',
+    group: 'block',
+    atom: true,
+    addOptions() {
+        return {
+            allowFullscreen: true,
+            HTMLAttributes: {
+                class: 'iframe-wrapper',
+            },
+        };
+    },
+    addAttributes() {
+        return {
+            src: {
+                default: null,
+            },
+            frameborder: {
+                default: 0,
+            },
+            allowfullscreen: {
+                default: this.options.allowFullscreen,
+                parseHTML: () => this.options.allowFullscreen,
+            },
+        };
+    },
+    parseHTML() {
+        return [
+            {
+                tag: 'iframe',
+            },
+        ];
+    },
+    renderHTML({ HTMLAttributes }) {
+        return ['div', this.options.HTMLAttributes, ['iframe', HTMLAttributes]];
+    },
+    addCommands() {
+        return {
+            setIframe: (options) => ({ tr, dispatch }) => {
+                const { selection } = tr;
+                const node = this.type.create(options);
+                if (dispatch) {
+                    tr.replaceRangeWith(selection.from, selection.to, node);
+                }
+                return true;
+            },
+        };
+    },
+});

--- a/dist/lib/editor/index.js
+++ b/dist/lib/editor/index.js
@@ -12,6 +12,7 @@ const Image_1 = __importDefault(require("./extensions/Image"));
 const Link_1 = __importDefault(require("./extensions/Link"));
 const ToC_1 = __importDefault(require("./extensions/ToC"));
 const Heading_1 = __importDefault(require("./extensions/Heading"));
+const IFrame_1 = __importDefault(require("./extensions/IFrame"));
 function extractLinkData(href) {
     const data = {};
     if (href.startsWith('@')) {
@@ -57,6 +58,7 @@ const editorExtensions = (editMode, context) => ([
     Aside_1.default,
     Heading_1.default,
     Image_1.default,
+    IFrame_1.default,
     Link_1.default.configure({
         enableClickSelection: editMode,
         openOnClick: !editMode,

--- a/dist/lib/renderContent.js
+++ b/dist/lib/renderContent.js
@@ -37,10 +37,11 @@ async function tryRenderContent(req, content, universeShortname) {
         };
         const htmlBody = (0, html_string_1.renderToHTMLString)({ extensions: (0, editor_1.editorExtensions)(false, renderContext), content: jsonBody });
         const sanitizedHtml = (0, sanitize_html_1.default)(htmlBody, {
-            allowedTags: sanitize_html_1.default.defaults.allowedTags.concat(['img']),
+            allowedTags: sanitize_html_1.default.defaults.allowedTags.concat(['img', 'iframe']),
             allowedAttributes: {
                 ...sanitize_html_1.default.defaults.allowedAttributes,
                 img: ['src', 'alt', 'title', 'width', 'height'],
+                iframe: ['src'],
                 h1: ['id'], h2: ['id'], h3: ['id'], h4: ['id'], h5: ['id'], h6: ['id'],
             },
             disallowedTagsMode: 'escape',

--- a/dist/static/assets/styles.css
+++ b/dist/static/assets/styles.css
@@ -1163,6 +1163,24 @@ input:checked + .slider:before {
   100% {transform: rotate(1turn)}
 }
 
+/* iFrames */
+.iframe-wrapper {
+  width: 100%;
+  padding-top: 56.25%;
+  position: relative;
+}
+
+.iframe-wrapper iframe {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 0.25rem;
+}
+
 /* Generic classes */
 .d-flex {
   display: flex;

--- a/dist/static/assets/styles.css
+++ b/dist/static/assets/styles.css
@@ -1170,7 +1170,7 @@ input:checked + .slider:before {
   position: relative;
 }
 
-.iframe-wrapper iframe {
+.iframe-wrapper>iframe {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -1181,6 +1181,9 @@ input:checked + .slider:before {
   border-radius: 0.25rem;
 }
 
+aside .iframe-wrapper>iframe {
+  border-radius: 0.75rem;
+}
 /* Generic classes */
 .d-flex {
   display: flex;

--- a/editor/src/components/EditorFrame.tsx
+++ b/editor/src/components/EditorFrame.tsx
@@ -5,7 +5,7 @@ import type { SetImageOptions } from '@tiptap/extension-image';
 
 type RichEditorProps = {
   editor: Editor;
-  getLink: (previousUrl: string, type: 'link' | 'image') => Promise<[string | null, { [attr: string]: any }?]>;
+  getLink: (previousUrl: string, type: 'link' | 'image' | 'videoembed') => Promise<[string | null, { [attr: string]: any }?]>;
 };
 
 function MenuBar({ editor, getLink }: RichEditorProps) {
@@ -35,6 +35,7 @@ function MenuBar({ editor, getLink }: RichEditorProps) {
         isBulletList: ctx.editor.isActive('bulletList') ?? false,
         isOrderedList: ctx.editor.isActive('orderedList') ?? false,
         isImage: ctx.editor.isActive('image') ?? false,
+        isVideoEmbed: ctx.editor.isActive('iframe') ?? false,
         isCodeBlock: ctx.editor.isActive('codeBlock') ?? false,
         isAside: ctx.editor.isActive('aside') ?? false,
         isBlockquote: ctx.editor.isActive('blockquote') ?? false,
@@ -83,6 +84,22 @@ function MenuBar({ editor, getLink }: RichEditorProps) {
           if (attrs.height) imgAttrs.height = attrs.height;
         }
         editor.chain().focus().setImage(imgAttrs).run();
+      } catch (e: any) {
+        alert(e.message);
+      }
+    });
+  }, [editor]);
+
+  const setVideoEmbed = useCallback(() => {
+    const previousSrc = editor.getAttributes('iframe').src;
+
+    getLink(previousSrc, 'videoembed').then(([src, _]) => {
+      if (src === null) {
+        return;
+      }
+
+      try {
+        editor.chain().focus().setIframe({ src }).run();
       } catch (e: any) {
         alert(e.message);
       }
@@ -231,6 +248,14 @@ function MenuBar({ editor, getLink }: RichEditorProps) {
         title={T('Insert Image')}
       >
         image
+      </button>
+      <button
+        onMouseDown={e => e.preventDefault()}
+        onClick={setVideoEmbed}
+        className={`material-symbols-outlined ${editorState.isVideoEmbed ? 'is-active' : ''}`}
+        title={T('Embed Video')}
+      >
+        subscriptions
       </button>
       <button
         onMouseDown={e => e.preventDefault()}

--- a/src/lib/editor/extensions/IFrame.ts
+++ b/src/lib/editor/extensions/IFrame.ts
@@ -1,0 +1,75 @@
+import { Node } from '@tiptap/core';
+
+export interface IframeOptions {
+  allowFullscreen: boolean
+  HTMLAttributes: {
+    [key: string]: any,
+  }
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    iframe: {
+      setIframe: (options: { src: string }) => ReturnType,
+    }
+  }
+}
+
+export default Node.create<IframeOptions>({
+  name: 'iframe',
+  group: 'block',
+  atom: true,
+
+  addOptions() {
+    return {
+      allowFullscreen: true,
+      HTMLAttributes: {
+        class: 'iframe-wrapper',
+      },
+    };
+  },
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+      },
+      frameborder: {
+        default: 0,
+      },
+      allowfullscreen: {
+        default: this.options.allowFullscreen,
+        parseHTML: () => this.options.allowFullscreen,
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'iframe',
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', this.options.HTMLAttributes, ['iframe', HTMLAttributes]];
+  },
+
+  addCommands() {
+    return {
+      setIframe:
+        (options: { src: string }) =>
+          ({ tr, dispatch }) => {
+            const { selection } = tr;
+            const node = this.type.create(options);
+
+            if (dispatch) {
+              tr.replaceRangeWith(selection.from, selection.to, node);
+            }
+
+            return true;
+          },
+    };
+  },
+});

--- a/src/lib/editor/index.ts
+++ b/src/lib/editor/index.ts
@@ -4,6 +4,7 @@ import Image from './extensions/Image';
 import Link, { ResolveResult } from './extensions/Link';
 import ToC from './extensions/ToC';
 import Heading from './extensions/Heading';
+import IFrame from './extensions/IFrame';
 
 export interface TiptapContext {
   currentUniverse: string;
@@ -70,6 +71,7 @@ export const editorExtensions = (editMode: boolean, context?: TiptapContext) => 
   Aside,
   Heading,
   Image,
+  IFrame,
   Link.configure({
     enableClickSelection: editMode,
     openOnClick: !editMode,

--- a/src/lib/renderContent.ts
+++ b/src/lib/renderContent.ts
@@ -39,10 +39,11 @@ export async function tryRenderContent(req: Request, content: unknown, universeS
     };
     const htmlBody = renderToHTMLString({ extensions: editorExtensions(false, renderContext), content: jsonBody });
     const sanitizedHtml = sanitizeHtml(htmlBody, {
-      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+      allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'iframe']),
       allowedAttributes: {
         ...sanitizeHtml.defaults.allowedAttributes,
         img: ['src', 'alt', 'title', 'width', 'height'],
+        iframe: ['src'],
         h1: ['id'], h2: ['id'], h3: ['id'], h4: ['id'], h5: ['id'], h6: ['id'],
       },
       disallowedTagsMode: 'escape',

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -19,7 +19,7 @@ html(lang='en')
         'key_vertical', 'workspace_premium', 'format_bold', 'format_italic', 'strikethrough_s', 'code_blocks',
         'format_paragraph', 'format_h1', 'format_h2', 'format_h3', 'format_h4', 'format_h5', 'format_h6',
         'format_list_bulleted', 'format_list_numbered', 'code', 'format_quote', 'horizontal_rule', 'undo', 'redo',
-        'format_clear', 'view_sidebar', 'link', 'link_off', 'image', 'toc', 'experiment', 'security', 'menu'
+        'format_clear', 'view_sidebar', 'link', 'link_off', 'image', 'toc', 'experiment', 'security', 'subscriptions'
 
       ].sort();
     link(rel='stylesheet' href=`https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=${icons.join(',')}`)


### PR DESCRIPTION
closes #146

Allow embedding videos (most likely youtube videos) using iframes. The frames are responsive, and will take up the full width available to them, always keeping an aspect ratio of 16:9.