### PR TITLE
Add drag-and-drop + gallery fixes

### DIFF
--- a/dist/db/schema.sql
+++ b/dist/db/schema.sql
@@ -264,6 +264,7 @@ CREATE TABLE itemimage (
   image_id INT NOT NULL,
   item_id INT NOT NULL,
   label VARCHAR(256) NOT NULL,
+  idx INT NOT NULL,
   FOREIGN KEY (item_id) REFERENCES item (id) ON DELETE CASCADE,
   FOREIGN KEY (image_id) REFERENCES image (id) ON DELETE CASCADE
 );

--- a/dist/static/assets/styles.css
+++ b/dist/static/assets/styles.css
@@ -488,6 +488,14 @@ header {
   margin-top: 0.5rem;
 }
 
+.item-gallery img {
+  border-radius: 0.325rem;
+  background-color: #e9e9e9;
+  cursor: grab;
+  object-fit: contain;
+  min-height: 0;
+}
+
 .notes {
   display: grid;
   grid-template-columns: 2fr 1fr;
@@ -1493,6 +1501,10 @@ input:checked + .slider:before {
 }
 .w-100 {
   width: 100%;
+}
+
+.h-100 {
+  height: 100%;
 }
 
 .scroll-x {

--- a/dist/static/scripts/modal.js
+++ b/dist/static/scripts/modal.js
@@ -2,6 +2,7 @@ if (!window.createElement) throw 'domUtils.js not loaded!';
 
 (function() {
   const modals = {};
+  const onCloses = {};
   const anchor = new Promise((resolve) => {
     window.addEventListener('load', () => {
       resolve(document.querySelector('#modal-anchor'));
@@ -15,7 +16,10 @@ if (!window.createElement) throw 'domUtils.js not loaded!';
       id,
       onclick: () => hideModal(id),
     }, classList: ['modal', 'hidden'], children: [
-      createElement('div', { classList: ['modal-content'], attrs: {onclick: (e) => e.stopPropagation()}, children }),
+      createElement('div', { classList: ['modal-content'], attrs: {onclick: (e) => {
+        e.stopPropagation();
+        onCloses[id] && onCloses[id]();
+      }}, children }),
     ] });
     modals[id] = newModal;
     if (show) showModal(id);
@@ -35,6 +39,10 @@ if (!window.createElement) throw 'domUtils.js not loaded!';
     modals[id].remove();
   }
 
+  function setOnClose(id, onClose) {
+    onCloses[id] = onClose;
+  }
+
   async function loadModal(id, show=false) {
     const modalEl = document.getElementById(id);
     if (!modalEl) return null;
@@ -52,13 +60,17 @@ if (!window.createElement) throw 'domUtils.js not loaded!';
     const modalEl = document.getElementById(id);
     modalEl.innerHTML = '';
     if (!(content instanceof Array)) content = [content];
-    modalEl.appendChild(createElement('div', { classList: ['modal-content'], attrs: {onclick: (e) => e.stopPropagation()}, children: content }));
+    modalEl.appendChild(createElement('div', { classList: ['modal-content'], attrs: {onclick: (e) => {
+      e.stopPropagation();
+      onCloses[id] && onCloses[id]();
+    }}, children: content }));
   }
 
   window.modal = modal;
   window.showModal = showModal;
   window.hideModal = hideModal;
   window.removeModal = removeModal;
+  window.setOnClose = setOnClose;
   window.loadModal = loadModal;
   window.replaceContent = replaceContent;
 })();

--- a/dist/views/pages/item.js
+++ b/dist/views/pages/item.js
@@ -63,9 +63,6 @@ exports.default = {
         item.obj_data = JSON.parse(item.obj_data);
         item.itemTypeName = ((universe.obj_data['cats'] ?? {})[item.item_type] ?? ['Missing Category'])[0];
         item.itemTypeColor = ((universe.obj_data['cats'] ?? {})[item.item_type] ?? [, , '#f3f3f3'])[2];
-        // if (item.gallery && item.gallery.length > 0) {
-        //   item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
-        // }
         let renderedBody = { type: 'text', content: '' };
         if ('body' in item.obj_data) {
             renderedBody = await (0, renderContent_1.tryRenderContent)(req, item.obj_data.body, universe.shortname);

--- a/dist/views/pages/item.js
+++ b/dist/views/pages/item.js
@@ -63,9 +63,9 @@ exports.default = {
         item.obj_data = JSON.parse(item.obj_data);
         item.itemTypeName = ((universe.obj_data['cats'] ?? {})[item.item_type] ?? ['Missing Category'])[0];
         item.itemTypeColor = ((universe.obj_data['cats'] ?? {})[item.item_type] ?? [, , '#f3f3f3'])[2];
-        if (item.gallery && item.gallery.length > 0) {
-            item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
-        }
+        // if (item.gallery && item.gallery.length > 0) {
+        //   item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
+        // }
         let renderedBody = { type: 'text', content: '' };
         if ('body' in item.obj_data) {
             renderedBody = await (0, renderContent_1.tryRenderContent)(req, item.obj_data.body, universe.shortname);

--- a/editor/src/components/Gallery.tsx
+++ b/editor/src/components/Gallery.tsx
@@ -1,8 +1,11 @@
-import { useState } from 'react';
-import { postFormData, T } from '../helpers';
-import { createPortal } from 'react-dom';
-import type { GalleryImage } from '../../../src/api/models/item';
+import { closestCenter, DndContext, KeyboardSensor, PointerSensor, TouchSensor, useSensor, useSensors, type DragEndEvent, type UniqueIdentifier } from '@dnd-kit/core';
+import { arrayMove, rectSortingStrategy, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { HttpStatusCode } from 'axios';
+import { useCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { type GalleryImage } from '../../../src/api/models/item';
+import { postFormData, T } from '../helpers';
+import GalleryImageCard from './GalleryImageCard';
 
 type GalleryProps = {
   universe: string,
@@ -11,27 +14,72 @@ type GalleryProps = {
   onRemoveImage: (id: number) => void,
   onUploadImage: (img: GalleryImage) => void,
   onChangeLabel: (id: number, label: string) => void,
+  onReorderImages: (newImages: GalleryImage[]) => void,
 };
 
-export default function Gallery({ universe, item, images, onRemoveImage, onUploadImage, onChangeLabel }: GalleryProps) {
+export default function Gallery({ universe, item, images, onRemoveImage, onUploadImage, onChangeLabel, onReorderImages }: GalleryProps) {
   const [uploadModal, setUploadModal] = useState<boolean>(false);
   const [uploadModalError, setUploadModalError] = useState<string>('');
   const modalAnchor = document.querySelector('#modal-anchor') as HTMLElement;
 
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 150,
+        tolerance: 5,
+      },
+    }),
+  );
+
+  const [localImages, setLocalImages] = useState(images);
+  const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+
+  const handleDragStart = useCallback((event: DragEndEvent) => {
+    setActiveId(event.active.id);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over) return;
+      if (active.id !== over.id) {
+        const oldIndex = localImages.findIndex(img => img.id === active.id);
+        const newIndex = localImages.findIndex(img => img.id === over.id);
+        const newOrder = arrayMove(localImages, oldIndex, newIndex);
+        setLocalImages(newOrder);
+        onReorderImages(newOrder);
+      }
+      setActiveId(null);
+    },
+    [onReorderImages]
+  );
+
+  const handleDragCancel = useCallback(() => setActiveId(null), []);
+
   return <>
-    <div className='item-gallery d-flex gap-4 flex-wrap'>
-      {images.map((img, i) => (
-        <div>
-          <div className='d-flex gap-1' style={{ height: '8rem' }}>
-            <img src={`/api/universes/${universe}/items/${item}/gallery/images/${img.id}`} alt={img.label} />
-            <div className='d-flex flex-col'>
-              <button type='button' onClick={() => onRemoveImage(img.id)}>{T('Remove Image')}</button>
-              <input value={img.label ?? ''} placeholder='Label' onChange={({ target }) => onChangeLabel(img.id, target.value)} />
-              <a className='link link-animated align-self-start' href={`/api/universes/${universe}/items/${item}/gallery/images/${img.id}?download=1`}>{T('Download')}</a>
-            </div>
-          </div>
-        </div>
-      ))}
+    <div className='item-gallery d-flex gap-4 flex-wrap justify-center'>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <SortableContext items={localImages.map(i => i.id)} strategy={rectSortingStrategy}>
+          {localImages.map((img) => (
+            <GalleryImageCard
+              id={img.id}
+              src={`/api/universes/${universe}/items/${item}/gallery/images/${img.id}`}
+              label={img.label}
+              onRemoveImage={onRemoveImage}
+              onChangeLabel={onChangeLabel}
+              isDragging={activeId === img.id}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
     </div>
     <button type='button' onClick={() => setUploadModal(true)}>{T('Upload Image')}</button>
     {uploadModal && (

--- a/editor/src/components/GalleryImageCard.tsx
+++ b/editor/src/components/GalleryImageCard.tsx
@@ -1,0 +1,58 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { T } from '../helpers';
+import type React from 'react';
+
+type GalleryImageProps = {
+  id: number,
+  src: string,
+  label: string,
+  onRemoveImage: (id: number) => void,
+  onChangeLabel: (id: number, label: string) => void,
+  isDragging?: boolean,
+};
+
+export default function GalleryImageCard({ id, src, label, onRemoveImage, onChangeLabel, isDragging }: GalleryImageProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    padding: '8px 12px',
+    marginBottom: '8px',
+    border: '1px solid #ccc',
+    borderRadius: '8px',
+    backgroundColor: 'white',
+    height: '24rem',
+    width: '16rem',
+    boxShadow: isDragging ? '0 0.5rem 1rem 0 rgb(0 0 0 / 30%)' : '0 0.25rem 0.5rem 0 rgb(0 0 0 / 20%)',
+    touchAction: 'none',
+  };
+
+  return (
+    <div key={id} ref={setNodeRef} style={style}>
+      <div className='d-flex flex-col gap-2 justify-between h-100'>
+        <img src={src} alt={label} {...listeners} {...attributes} />
+        <div className='d-flex flex-col'>
+          <button type='button' onClick={() => onRemoveImage(id)}>{T('Remove Image')}</button>
+          <input value={label ?? ''} placeholder='Label' onChange={({ target }) => onChangeLabel(id, target.value)} />
+          <a className='link link-animated align-self-start' href={`${src}?download=1`}>{T('Download')}</a>
+          <div
+            className='mt-1 d-flex align-center justify-center clickable'
+            style={{ height: '2rem', backgroundColor: '#e9e9e9', borderRadius: '0.325rem', touchAction: 'none' }}
+            {...listeners}
+            {...attributes}
+          >
+            <span className='material-symbols-outlined'>menu</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/editor/src/pages/ItemEdit.tsx
+++ b/editor/src/pages/ItemEdit.tsx
@@ -265,9 +265,11 @@ export default function ItemEdit({ universeLink }: ItemEditProps) {
           }
         }
         setItem(newState);
-      }} onUploadImage={(img) => {
+      }} onUploadImages={(imgs) => {
         const newState = { ...item };
-        newState.gallery.push(img);
+        for (const img of imgs) {
+          newState.gallery.push(img);
+        }
         setItem(newState);
       }} onChangeLabel={(id, label) => {
         const newState = { ...item };

--- a/editor/src/pages/ItemEdit.tsx
+++ b/editor/src/pages/ItemEdit.tsx
@@ -279,6 +279,11 @@ export default function ItemEdit({ universeLink }: ItemEditProps) {
           }
         }
         setItem(newState);
+      }} onReorderImages={(newImages) => {
+        setItem(prev => prev ? ({
+          ...prev,
+          gallery: newImages,
+        }) : prev);
       }} />
     ),
     timeline: (

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   },
   "homepage": "https://archivium.net",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@tiptap/extension-image": "^3.0.9",
     "@tiptap/html": "^3.3.0",
     "@tiptap/react": "^3.0.9",

--- a/src/views/pages/item.ts
+++ b/src/views/pages/item.ts
@@ -67,9 +67,6 @@ export default {
     item.obj_data = JSON.parse(item.obj_data as string) as Record<string, any>;
     item.itemTypeName = ((universe.obj_data['cats'] ?? {})[item.item_type] ?? ['Missing Category'])[0];
     item.itemTypeColor = ((universe.obj_data['cats'] ?? {})[item.item_type] ?? [,,'#f3f3f3'])[2];
-    // if (item.gallery && item.gallery.length > 0) {
-    //   item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
-    // }
 
     let renderedBody: RenderedBody = { type: 'text', content: '' };
     if ('body' in item.obj_data) {

--- a/src/views/pages/item.ts
+++ b/src/views/pages/item.ts
@@ -67,9 +67,9 @@ export default {
     item.obj_data = JSON.parse(item.obj_data as string) as Record<string, any>;
     item.itemTypeName = ((universe.obj_data['cats'] ?? {})[item.item_type] ?? ['Missing Category'])[0];
     item.itemTypeColor = ((universe.obj_data['cats'] ?? {})[item.item_type] ?? [,,'#f3f3f3'])[2];
-    if (item.gallery && item.gallery.length > 0) {
-      item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
-    }
+    // if (item.gallery && item.gallery.length > 0) {
+    //   item.gallery = item.gallery.sort((a, b) => a.id > b.id ? 1 : -1);
+    // }
 
     let renderedBody: RenderedBody = { type: 'text', content: '' };
     if ('body' in item.obj_data) {

--- a/templates/layout.pug
+++ b/templates/layout.pug
@@ -17,7 +17,7 @@ html(lang='en')
         'edit', 'add', 'cancel', 'delete', 'settings', 'logout', 'person', 'notifications_active', 'notifications',
         'mark_email_unread', 'drafts', 'visibility_off', 'drag_indicator', 'arrow_forward_ios', 'arrow_back_ios',
         'key_vertical', 'workspace_premium', 'format_bold', 'format_italic', 'strikethrough_s', 'code_blocks',
-        'format_paragraph', 'format_h1', 'format_h2', 'format_h3', 'format_h4', 'format_h5', 'format_h6',
+        'format_paragraph', 'format_h1', 'format_h2', 'format_h3', 'format_h4', 'format_h5', 'format_h6', 'menu',
         'format_list_bulleted', 'format_list_numbered', 'code', 'format_quote', 'horizontal_rule', 'undo', 'redo',
         'format_clear', 'view_sidebar', 'link', 'link_off', 'image', 'toc', 'experiment', 'security', 'subscriptions'
 

--- a/templates/view/item.pug
+++ b/templates/view/item.pug
@@ -273,6 +273,9 @@ block content
           content.classList.remove('itemKey');
           replaceContent('gallery-fullscreen-modal', content);
           showModal('gallery-fullscreen-modal');
+          setOnClose('gallery-fullscreen-modal', () => {
+            hideModal('gallery-fullscreen-modal');
+          });
         };
       });
     })();


### PR DESCRIPTION
closes #165, closes #239

Allow drag-and-dropping image in the gallery editor:
<img width="1280" height="780" alt="image" src="https://github.com/user-attachments/assets/f688eb7f-e665-4bae-b24b-38646390b2b7" />

This works in mobile too. Also:

- Allow closing the gallery view by tapping on the image, preventing mobile users from getting stuck on the image preview.
- Allow uploading multiple images at once.